### PR TITLE
Remove console.log from callback

### DIFF
--- a/jquery.simpleWeather.js
+++ b/jquery.simpleWeather.js
@@ -196,7 +196,6 @@
 								link: result.item.link
 							};
 
-							console.log(weather);
 							options.success(weather);
 						});
 					} else {


### PR DESCRIPTION
I don't know if this was intentional, but this should probably be removed. `console.log` is not supported across every browser and it clogs up a console if you don't intend to use this information. Potentially could be added back in with some sort of `debug` mode.
