### PR TITLE
Do not assume `query` is present in response.

### DIFF
--- a/jquery.simpleWeather.js
+++ b/jquery.simpleWeather.js
@@ -37,7 +37,7 @@
       $.getJSON(
         encodeURI(weatherUrl),
         function(data) {
-          if(data !== null && data.query.results !== null && data.query.results.channel.description !== 'Yahoo! Weather Error') {
+          if(data !== null && data.query !== null && data.query.results !== null && data.query.results.channel.description !== 'Yahoo! Weather Error') {
             $.each(data.query.results, function(i, result) {
               if (result.constructor.toString().indexOf("Array") !== -1) {
                 result = result[0];


### PR DESCRIPTION
The Yahoo simple weather API returns an error when searching for "Ponoka, AB".

The returned JSON is:

``` javascript
{"error":{"lang":"en-US","diagnostics":null,"description":"No definition found
for Table weather.search"}}
```

This causes `simpleWeather` to error since it assumes that the results contain
a `query` key.

---

I am unsure how you generally update the minified output as I didn't see a build script in the repo.
